### PR TITLE
Bump version of Excon

### DIFF
--- a/pco_api.gemspec
+++ b/pco_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "faraday", "~> 0.10"
   s.add_dependency "faraday_middleware", "~> 0.10"
-  s.add_dependency "excon", "~> 0.45.3"
+  s.add_dependency "excon", ">= 0.71.0"
   s.add_development_dependency "rspec", "~> 3.2"
   s.add_development_dependency "webmock", "~> 1.21"
   s.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
This addresses a low severity CVE in the excon gem. 
See https://github.com/advisories/GHSA-q58g-455p-8vw9
