### PR TITLE
Add headers to results and handle 429 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 *.gem
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 Gemfile.lock
 *.gem
-*.swp

--- a/lib/pco/api/endpoint.rb
+++ b/lib/pco/api/endpoint.rb
@@ -67,7 +67,6 @@ module PCO
       private
 
       def _build_response(result)
-        # puts result.headers.select { |k, _v| k.match /X-PCO-API/ }
         case result.status
         when 200..299
           res = result.body

--- a/lib/pco/api/endpoint.rb
+++ b/lib/pco/api/endpoint.rb
@@ -67,7 +67,7 @@ module PCO
       private
 
       def _build_response(result)
-        puts result.headers.select { |k, _v| k.match /X-PCO-API/ }
+        # puts result.headers.select { |k, _v| k.match /X-PCO-API/ }
         case result.status
         when 200..299
           res = result.body

--- a/lib/pco/api/endpoint.rb
+++ b/lib/pco/api/endpoint.rb
@@ -67,9 +67,12 @@ module PCO
       private
 
       def _build_response(result)
+        puts result.headers.select { |k, _v| k.match /X-PCO-API/ }
         case result.status
         when 200..299
-          result.body
+          res = result.body
+          res['headers'] = result.headers
+          res
         when 400
           fail Errors::BadRequest, result
         when 401
@@ -82,6 +85,8 @@ module PCO
           fail Errors::MethodNotAllowed, result
         when 422
           fail Errors::UnprocessableEntity, result
+        when 429
+          fail Errors::TooManyRequests, result
         when 400..499
           fail Errors::ClientError, result
         when 500

--- a/lib/pco/api/errors.rb
+++ b/lib/pco/api/errors.rb
@@ -52,6 +52,7 @@ module PCO
       class NotFound            < ClientError; end # 404
       class MethodNotAllowed    < ClientError; end # 405
       class UnprocessableEntity < ClientError; end # 422
+      class TooManyRequests     < ClientError; end # 429
 
       class ServerError         < BaseError;   end # 500..599
       class InternalServerError < ServerError; end # 500


### PR DESCRIPTION
The headers provide rate limiting information, but were not included in the request response. I have added the headers to the response.

The 429 error occurs when there are too many API requests. I have added code to specifically check for the 429 error and handle it like the other errors.