### PR TITLE
Fix bug with arguments in Ruby 3

### DIFF
--- a/lib/pco/api.rb
+++ b/lib/pco/api.rb
@@ -4,8 +4,8 @@ require_relative 'api/errors'
 module PCO
   module API
     module_function
-    def new(*args)
-      Endpoint.new(*args)
+    def new(**args)
+      Endpoint.new(**args)
     end
   end
 end

--- a/spec/pco/api_spec.rb
+++ b/spec/pco/api_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../spec_helper'
+
+describe PCO::API do
+  describe '.new' do
+    it 'creates a new Endpoint instance' do
+      expect(described_class.new(basic_auth_token: 'abc123', basic_auth_secret: 'xyz789').class).to eq(PCO::API::Endpoint)
+    end
+  end
+end


### PR DESCRIPTION
This fixes the bug in Ruby 3:

```
lib/pco/api/endpoint.rb:15:in `initialize': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from lib/ruby/gems/3.0.0/gems/pco_api-1.3.0/lib/pco/api.rb:8:in `new'
```