### PR TITLE
feat(RateLimiting): automatically retry requests when rate limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ In the case of validation errors, the `message` is a summary string built from t
 Alternatively, you may rescue `PCO::API::Errors::BaseError` and branch your code based on
 the status code returned by calling `error.status`.
 
+### TooManyRequests Error
+
+By default, PCO::API::Endpoint will sleep and retry a request that fails with TooManyRequests due
+to rate limiting. If you would rather catch and handle such errors yourself, you can disable this
+behavior like this:
+
+```ruby
+api = PCO::API.new(...)
+api.retry_when_rate_limited = false
+```
+
 ## Copyright & License
 
 Copyright Ministry Centered Technologies. Licensed MIT.

--- a/lib/pco/api.rb
+++ b/lib/pco/api.rb
@@ -3,9 +3,10 @@ require_relative 'api/errors'
 
 module PCO
   module API
-    module_function
-    def new(**args)
-      Endpoint.new(**args)
+    class << self
+      def new(**args)
+        Endpoint.new(**args)
+      end
     end
   end
 end


### PR DESCRIPTION
We will sleep the prescribed number of seconds, then retry the request.

To disable, you can set `retry_when_rate_limited` to false.