### PR TITLE
fix(Request): Faraday request not sending JSON properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1 (April 24, 2024)
+
+- Fix: Tell Faraday to use JSON for the request
+
 # 2.1.0 (April 14, 2023)
 
 - Chore: Use 2.x version of Faraday

--- a/lib/pco/api/endpoint.rb
+++ b/lib/pco/api/endpoint.rb
@@ -139,6 +139,7 @@ module PCO
 
       def _build_connection
         Faraday.new(url: url) do |faraday|
+          faraday.request :json
           faraday.response :json, content_type: /\bjson$/
           if @basic_auth_token && @basic_auth_secret
             faraday.request :authorization, :basic, @basic_auth_token, @basic_auth_secret


### PR DESCRIPTION
I don't know when this broke, but it seems that newer versions of Faraday require us to explicitly say we are using JSON for the request.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207162760637305