### PR TITLE
Don't url-encode params to oauth endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.2 (July 11, 2024)
+
+- Fix: Don't url-encode parameters to `/oauth` endpoints
+
 # 2.1.1 (April 24, 2024)
 
 - Fix: Tell Faraday to use JSON for the request

--- a/lib/pco/api/endpoint.rb
+++ b/lib/pco/api/endpoint.rb
@@ -52,7 +52,7 @@ module PCO
 
       def post(body = {})
         @last_result = @connection.post(@url) do |req|
-          req.body = _build_body(body)
+          req.body = body.to_json
         end
         _build_response(@last_result)
       rescue Errors::TooManyRequests => e
@@ -61,7 +61,7 @@ module PCO
 
       def patch(body = {})
         @last_result = @connection.patch(@url) do |req|
-          req.body = _build_body(body)
+          req.body = body.to_json
         end
         _build_response(@last_result)
       rescue Errors::TooManyRequests => e
@@ -114,18 +114,6 @@ module PCO
         else
           fail "unknown status #{result.status}"
         end
-      end
-
-      def _build_body(body)
-        if _needs_url_encoded?
-          Faraday::Utils.build_nested_query(body)
-        else
-          body.to_json
-        end
-      end
-
-      def _needs_url_encoded?
-        @url =~ /oauth\/[a-z]+\z/
       end
 
       def _build_endpoint(path)

--- a/lib/pco/api/version.rb
+++ b/lib/pco/api/version.rb
@@ -1,5 +1,5 @@
 module PCO
   module API
-    VERSION = '2.1.1'
+    VERSION = '2.1.2'
   end
 end


### PR DESCRIPTION
This broke when we upgraded the OAuth server.